### PR TITLE
Trying out Gamma as default distribution for Multiplicative models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: smooth
 Type: Package
 Title: Forecasting Using State Space Models
-Version: 3.1.2.41017
+Version: 3.1.2.41018
 Date: 2021-05-10
 Authors@R: person("Ivan", "Svetunkov", email = "ivan@svetunkov.ru", role = c("aut", "cre"),
                   comment="Lecturer at Centre for Marketing Analytics and Forecasting, Lancaster University, UK")

--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,7 @@ Changes:
 * adam() now does regressors selection between those that are specified in formula if formula is provided.
 * More iterations for xreg models in adam().
 * Refine head of time series in adam() for backcasting (previously was only done for optimal).
+* Gamma is now the default distribution for Etype="M" in ETS.
 
 Bugfixes:
 * Fixed a bug in adam() with regressors="select" and errorType=="M".

--- a/R/adam.R
+++ b/R/adam.R
@@ -44,7 +44,7 @@ utils::globalVariables(c("adamFitted","algorithm","arEstimate","arOrders","arReq
 #' are regulated via the \code{distribution} parameter. This includes:
 #' \enumerate{
 #' \item \code{default} - Normal distribution is used for the Additive error models,
-#' Inverse Gaussian is used for the Multiplicative error models.
+#' Gamma is used for the Multiplicative error models.
 #' \item dnorm - \link[stats]{Normal} distribution,
 #' \item \link[greybox]{dlaplace} - Laplace distribution,
 #' \item \link[greybox]{ds} - S distribution,
@@ -2557,7 +2557,7 @@ adam <- function(data, model="ZXZ", lags=c(frequency(data)), orders=list(ar=c(0)
         # If the distribution is default, change it according to the error term
         if(distribution=="default"){
             distributionNew <- switch(loss,
-                                      "likelihood"= switch(Etype, "A"= "dnorm", "M"= "dinvgauss"),
+                                      "likelihood"= switch(Etype, "A"= "dnorm", "M"= "dgamma"),
                                       "MAEh"=, "MACE"=, "MAE"= "dlaplace",
                                       "HAMh"=, "CHAM"=, "HAM"= "ds",
                                       "MSEh"=, "MSCE"=, "MSE"=, "GPL"=, "dnorm");
@@ -3482,7 +3482,7 @@ adam <- function(data, model="ZXZ", lags=c(frequency(data)), orders=list(ar=c(0)
         # If the distribution is default, change it according to the error term
         if(distribution=="default"){
             distribution[] <- switch(loss,
-                                     "likelihood"= switch(Etype, "A"= "dnorm", "M"= "dinvgauss"),
+                                     "likelihood"= switch(Etype, "A"= "dnorm", "M"= "dgamma"),
                                      "MAEh"=, "MACE"=, "MAE"= "dlaplace",
                                      "HAMh"=, "CHAM"=, "HAM"= "ds",
                                      "MSEh"=, "MSCE"=, "MSE"=, "GPL"=, "dnorm");
@@ -4045,7 +4045,7 @@ adam <- function(data, model="ZXZ", lags=c(frequency(data)), orders=list(ar=c(0)
         # If the distribution is default, change it according to the error term
         if(distribution=="default"){
             distributionNew <- switch(loss,
-                                      "likelihood"= switch(Etype, "A"= "dnorm", "M"= "dinvgauss"),
+                                      "likelihood"= switch(Etype, "A"= "dnorm", "M"= "dgamma"),
                                       "MAEh"=, "MACE"=, "MAE"= "dlaplace",
                                       "HAMh"=, "CHAM"=, "HAM"= "ds",
                                       "MSEh"=, "MSCE"=, "MSE"=, "GPL"=, "dnorm");

--- a/man/adam.Rd
+++ b/man/adam.Rd
@@ -334,7 +334,7 @@ The error term \eqn{\epsilon_t} can follow different distributions, which
 are regulated via the \code{distribution} parameter. This includes:
 \enumerate{
 \item \code{default} - Normal distribution is used for the Additive error models,
-Inverse Gaussian is used for the Multiplicative error models.
+Gamma is used for the Multiplicative error models.
 \item dnorm - \link[stats]{Normal} distribution,
 \item \link[greybox]{dlaplace} - Laplace distribution,
 \item \link[greybox]{ds} - S distribution,


### PR DESCRIPTION
Gamma is now the default distribution instead of Inverse Gaussian. It doesn't have as fat tails and works better than the latter.