### PR TITLE
first pybind11 wrapper for the smooth cpp code!

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -28,3 +28,9 @@ target_link_libraries(_my_linalg
 )
 
 install(TARGETS _my_linalg DESTINATION smooth/my_linalg)
+
+# Adam General
+pybind11_add_module(_adam_general ../src/python_examples/adamGeneral.cpp)
+target_link_libraries(_adam_general PRIVATE carma::carma ${ARMADILLO_LIBRARIES})
+target_include_directories(_adam_general PRIVATE ../src/python_examples/.)
+install(TARGETS _adam_general DESTINATION smooth/adam_general)

--- a/python/smooth/adam_general/__init__.py
+++ b/python/smooth/adam_general/__init__.py
@@ -1,0 +1,3 @@
+from _adam_general import adam_fitter
+
+__all__ = ["adam_fitter"]

--- a/python/smooth/adam_general/__init__.py
+++ b/python/smooth/adam_general/__init__.py
@@ -1,3 +1,3 @@
-from _adam_general import adam_fitter
+from ._adam_general import adam_fitter
 
 __all__ = ["adam_fitter"]

--- a/src/python_examples/adamGeneral.cpp
+++ b/src/python_examples/adamGeneral.cpp
@@ -1,0 +1,187 @@
+#include <iostream>
+#include <cmath>
+
+#include <carma>
+#include <armadillo>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+#include <adamGeneral.h>
+
+namespace py = pybind11;
+
+// # Fitter for univariate models
+// Convert from Rcpp::List to pybind11::dict
+
+py::dict adamFitter(arma::mat &matrixVt, arma::mat const &matrixWt, arma::mat &matrixF, arma::vec const &vectorG,
+                    arma::uvec &lags, arma::umat const &profilesObserved, arma::mat profilesRecent,
+                    char const &E, char const &T, char const &S,
+                    unsigned int const &nNonSeasonal, unsigned int const &nSeasonal,
+                    unsigned int const &nArima, unsigned int const &nXreg, bool const &constant,
+                    arma::vec const &vectorYt, arma::vec const &vectorOt, bool const &backcast)
+{
+    /* # matrixVt should have a length of obs + lagsModelMax.
+     * # matrixWt is a matrix with nrows = obs
+     * # vecG should be a vector
+     * # lags is a vector of lags
+     */
+
+    int obs = vectorYt.n_rows;
+    unsigned int nETS = nNonSeasonal + nSeasonal;
+    int nComponents = matrixVt.n_rows;
+    int lagsModelMax = max(lags);
+
+    // Fitted values and the residuals
+    arma::vec vecYfit(obs, arma::fill::zeros);
+    arma::vec vecErrors(obs, arma::fill::zeros);
+
+    // Loop for the backcasting
+    unsigned int nIterations = 1;
+    if (backcast)
+    {
+        nIterations = 2;
+    }
+
+    // Loop for the backcast
+    for (unsigned int j = 1; j <= nIterations; j = j + 1)
+    {
+
+        // Refine the head (in order for it to make sense)
+        // This is only needed for ETS(*,Z,*) models, with trend.
+        // if(!backcast){
+        for (int i = 0; i < lagsModelMax; i = i + 1)
+        {
+            matrixVt.col(i) = profilesRecent(profilesObserved.col(i));
+            profilesRecent(profilesObserved.col(i)) = adamFvalue(profilesRecent(profilesObserved.col(i)),
+                                                                 matrixF, E, T, S, nETS, nNonSeasonal, nSeasonal, nArima, nComponents, constant);
+        }
+        // }
+        ////// Run forward
+        // Loop for the model construction
+        for (int i = lagsModelMax; i < obs + lagsModelMax; i = i + 1)
+        {
+
+            /* # Measurement equation and the error term */
+            vecYfit(i - lagsModelMax) = adamWvalue(profilesRecent(profilesObserved.col(i)),
+                                                   matrixWt.row(i - lagsModelMax), E, T, S,
+                                                   nETS, nNonSeasonal, nSeasonal, nArima, nXreg, nComponents, constant);
+
+            // If this is zero (intermittent), then set error to zero
+            if (vectorOt(i - lagsModelMax) == 0)
+            {
+                vecErrors(i - lagsModelMax) = 0;
+            }
+            else
+            {
+                vecErrors(i - lagsModelMax) = errorf(vectorYt(i - lagsModelMax), vecYfit(i - lagsModelMax), E);
+            }
+
+            /* # Transition equation */
+            profilesRecent(profilesObserved.col(i)) = adamFvalue(profilesRecent(profilesObserved.col(i)),
+                                                                 matrixF, E, T, S, nETS, nNonSeasonal, nSeasonal, nArima, nComponents, constant) +
+                                                      adamGvalue(profilesRecent(profilesObserved.col(i)), matrixF, matrixWt.row(i - lagsModelMax), E, T, S,
+                                                                 nETS, nNonSeasonal, nSeasonal, nArima, nXreg, nComponents, constant, vectorG, vecErrors(i - lagsModelMax));
+
+            matrixVt.col(i) = profilesRecent(profilesObserved.col(i));
+        }
+
+        ////// Backwards run
+        if (backcast && j < (nIterations))
+        {
+            // Change the specific element in the state vector to negative
+            if (T == 'A')
+            {
+                profilesRecent(1) = -profilesRecent(1);
+            }
+            else if (T == 'M')
+            {
+                profilesRecent(1) = 1 / profilesRecent(1);
+            }
+
+            for (int i = obs + lagsModelMax - 1; i >= lagsModelMax; i = i - 1)
+            {
+                /* # Measurement equation and the error term */
+                vecYfit(i - lagsModelMax) = adamWvalue(profilesRecent(profilesObserved.col(i)),
+                                                       matrixWt.row(i - lagsModelMax), E, T, S,
+                                                       nETS, nNonSeasonal, nSeasonal, nArima, nXreg, nComponents, constant);
+
+                // If this is zero (intermittent), then set error to zero
+                if (vectorOt(i - lagsModelMax) == 0)
+                {
+                    vecErrors(i - lagsModelMax) = 0;
+                }
+                else
+                {
+                    vecErrors(i - lagsModelMax) = errorf(vectorYt(i - lagsModelMax), vecYfit(i - lagsModelMax), E);
+                }
+
+                /* # Transition equation */
+                profilesRecent(profilesObserved.col(i)) = adamFvalue(profilesRecent(profilesObserved.col(i)),
+                                                                     matrixF, E, T, S, nETS, nNonSeasonal, nSeasonal, nArima, nComponents, constant) +
+                                                          adamGvalue(profilesRecent(profilesObserved.col(i)), matrixF,
+                                                                     matrixWt.row(i - lagsModelMax), E, T, S,
+                                                                     nETS, nNonSeasonal, nSeasonal, nArima, nXreg, nComponents, constant,
+                                                                     vectorG, vecErrors(i - lagsModelMax));
+            }
+
+            // Fill in the head of the series
+            for (int i = lagsModelMax - 1; i >= 0; i = i - 1)
+            {
+                profilesRecent(profilesObserved.col(i)) = adamFvalue(profilesRecent(profilesObserved.col(i)),
+                                                                     matrixF, E, T, S, nETS, nNonSeasonal, nSeasonal, nArima, nComponents, constant);
+
+                matrixVt.col(i) = profilesRecent(profilesObserved.col(i));
+            }
+
+            // Change back the specific element in the state vector
+            if (T == 'A')
+            {
+                profilesRecent(1) = -profilesRecent(1);
+            }
+            else if (T == 'M')
+            {
+                profilesRecent(1) = 1 / profilesRecent(1);
+            }
+        }
+    }
+
+    // return List::create(Named("matVt") = matrixVt, Named("yFitted") = vecYfit,
+    //                     Named("errors") = vecErrors, Named("profile") = profilesRecent);
+
+    // Create a Python dictionary to return results
+    py::dict result;
+    result["matVt"] = matrixVt;
+    result["yFitted"] = vecYfit;
+    result["errors"] = vecErrors;
+    result["profile"] = profilesRecent;
+
+    return result;
+}
+
+PYBIND11_MODULE(_adam_general, m)
+{
+    m.doc() = "Adam code"; // module docstring
+    m.def(
+        "adam_fitter",
+        &adamFitter,
+        "fits the adam model",
+        py::arg("matrixVt"),
+        py::arg("matrixWt"),
+        py::arg("matrixF"),
+        py::arg("vectorG"),
+        py::arg("lags"),
+        py::arg("profilesObserved"),
+        py::arg("profilesRecent"),
+        py::arg("E"),
+        py::arg("T"),
+        py::arg("S"),
+        py::arg("nNonSeasonal"),
+        py::arg("nSeasonal"),
+        py::arg("nArima"),
+        py::arg("nXreg"),
+        py::arg("constant"),
+        py::arg("vectorYt"),
+        py::arg("vectorOt"),
+        py::arg("backcast"));
+}

--- a/src/python_examples/adamGeneral.h
+++ b/src/python_examples/adamGeneral.h
@@ -1,0 +1,444 @@
+#include <armadillo>
+#include <iostream>
+#include <cmath>
+
+/* # Function returns value of w() -- y-fitted -- used in the measurement equation */
+inline double adamWvalue(arma::vec const &vecVt, arma::rowvec const &rowvecW,
+                         char const &E, char const &T, char const &S,
+                         unsigned int const &nETS, unsigned int const &nNonSeasonal,
+                         unsigned int const &nSeasonal, unsigned int const &nArima,
+                         unsigned int const &nXreg, unsigned int const &nComponents,
+                         bool const &constant)
+{
+    // vecVt is a vector here!
+    double yfit = 0;
+    if (E == 'M')
+    {
+        yfit = 1;
+    }
+    arma::mat vecYfit;
+
+    // If there is ETS, calculate the measurement
+    if (nETS > 0)
+    {
+        switch (S)
+        {
+        // ZZN
+        case 'N':
+            switch (T)
+            {
+            case 'N':
+                vecYfit = vecVt.row(0);
+                break;
+            case 'A':
+                vecYfit = rowvecW.cols(0, 1) * vecVt.rows(0, 1);
+                break;
+            case 'M':
+                // vecYfit = exp(rowvecW.cols(0,1) * log(vecVt.rows(0,1)));
+                vecYfit = arma::real(exp(rowvecW.cols(0, 1) *
+                                         log(arma::conv_to<arma::cx_vec>::from(vecVt.rows(0, 1)))));
+                break;
+            }
+            break;
+            // ZZA
+        case 'A':
+            switch (T)
+            {
+            case 'N':
+            case 'A':
+                vecYfit = rowvecW.cols(0, nETS - 1) * vecVt.rows(0, nETS - 1);
+                break;
+            case 'M':
+                // vecYfit = exp(rowvecW.cols(0,1) * log(vecVt.rows(0,1))) + rowvecW.cols(2,2+nSeasonal-1) * vecVt.rows(2,2+nSeasonal-1);
+                vecYfit = arma::real(exp(rowvecW.cols(0, 1) *
+                                         log(arma::conv_to<arma::cx_vec>::from(vecVt.rows(0, 1))))) +
+                          rowvecW.cols(2, 2 + nSeasonal - 1) * vecVt.rows(2, 2 + nSeasonal - 1);
+                break;
+            }
+            break;
+            // ZZM
+        case 'M':
+            switch (T)
+            {
+            case 'N':
+            case 'M':
+                switch (E)
+                {
+                case 'A':
+                    // Use complex numbers to avoid issues with negative states
+                    vecYfit = arma::real(exp(rowvecW.cols(0, nETS - 1) *
+                                             log(arma::conv_to<arma::cx_vec>::from(vecVt.rows(0, nETS - 1)))));
+                    break;
+                case 'M':
+                    vecYfit = exp(rowvecW.cols(0, nETS - 1) * log(vecVt.rows(0, nETS - 1)));
+                }
+                break;
+            case 'A':
+                vecYfit = rowvecW.cols(0, 1) * vecVt.rows(0, 1) * exp(rowvecW.cols(2, 2 + nSeasonal - 1) * log(vecVt.rows(2, 2 + nSeasonal - 1)));
+                break;
+            }
+            break;
+        }
+        yfit = as_scalar(vecYfit);
+    }
+
+    // ARIMA components
+    if (nArima > 0)
+    {
+        // If error is additive, add explanatory variables. Otherwise multiply by exp(ax)
+        switch (E)
+        {
+        case 'A':
+            yfit += as_scalar(rowvecW.cols(nETS, nETS + nArima - 1) *
+                              vecVt.rows(nETS, nETS + nArima - 1));
+            break;
+        case 'M':
+            yfit = yfit * as_scalar(exp(rowvecW.cols(nETS, nETS + nArima - 1) *
+                                        log(vecVt.rows(nETS, nETS + nArima - 1))));
+            break;
+        }
+    }
+
+    // Explanatory variables
+    if (nXreg > 0)
+    {
+        // If error is additive, add explanatory variables. Otherwise multiply by exp(ax)
+        switch (E)
+        {
+        case 'A':
+            yfit += as_scalar(rowvecW.cols(nETS + nArima, nComponents - 1) *
+                              vecVt.rows(nETS + nArima, nComponents - 1));
+            break;
+        case 'M':
+            yfit = yfit * as_scalar(exp(rowvecW.cols(nETS + nArima, nComponents - 1) *
+                                        vecVt.rows(nETS + nArima, nComponents - 1)));
+            break;
+        }
+    }
+    else
+    {
+        if (constant)
+        {
+            switch (E)
+            {
+            case 'A':
+                yfit += vecVt(nComponents - 1);
+                break;
+            case 'M':
+                yfit = yfit * vecVt(nComponents - 1);
+                break;
+            }
+        }
+    }
+
+    return yfit;
+}
+
+/* # Function returns value of r() -- additive or multiplicative error -- used in the error term of measurement equation.
+ This is mainly needed by sim.ets */
+inline double adamRvalue(arma::vec const &vecVt, arma::rowvec const &rowvecW,
+                         char const &E, char const &T, char const &S,
+                         unsigned int const &nETS, unsigned int const &nNonSeasonal,
+                         unsigned int const &nSeasonal, unsigned int const &nArima,
+                         unsigned int const &nXreg, unsigned int const &nComponents,
+                         bool const &constant)
+{
+
+    switch (E)
+    {
+    // MZZ
+    case 'M':
+        return adamWvalue(vecVt, rowvecW, E, T, S, nETS, nNonSeasonal, nSeasonal, nArima, nXreg, nComponents, constant);
+        break;
+        // AZZ
+    case 'A':
+    default:
+        return 1.0;
+    }
+}
+
+/* # Function returns value of f() -- new states without the update -- used in the transition equation */
+inline arma::vec adamFvalue(arma::vec const &matrixVt, arma::mat const &matrixF,
+                            char const E, char const T, char const S,
+                            unsigned int const &nETS, unsigned int const &nNonSeasonal,
+                            unsigned int const &nSeasonal, unsigned int const &nArima,
+                            unsigned int const &nComponents, bool const &constant)
+{
+    arma::vec matrixVtnew = matrixVt;
+
+    switch (T)
+    {
+    case 'N':
+    case 'A':
+        matrixVtnew = matrixF * matrixVt;
+        break;
+    case 'M':
+        if (nETS > 0)
+        {
+            // Use complex numbers to avoid issues in mixed models
+            matrixVtnew.rows(0, 1) = arma::real(exp(matrixF.submat(0, 0, 1, 1) *
+                                                    log(arma::conv_to<arma::cx_vec>::from(matrixVt.rows(0, 1)))));
+            // matrixVtnew.rows(0,1) = exp(matrixF.submat(0,0,1,1) * log(matrixVt.rows(0,1)));
+        }
+        break;
+    }
+
+    // If there is ARIMA, fix the states for E='M'
+    if (nArima > 0 && E == 'M')
+    {
+        matrixVtnew.rows(nETS, nETS + nArima - 1) =
+            exp(matrixF.submat(nETS, nETS, nETS + nArima - 1, nETS + nArima - 1) *
+                log(matrixVt.rows(nETS, nETS + nArima - 1)));
+    }
+
+    // If there is a constant, fix the first state of ETS(M,*,*)
+    if (constant && nETS > 0 && E == 'M')
+    {
+        matrixVtnew.row(0) = (matrixVtnew.row(0) - matrixVt.row(nComponents - 1)) % matrixVt.row(nComponents - 1);
+    }
+
+    return matrixVtnew;
+}
+
+/* # Function returns value of g() -- the update of states -- used in components estimation for the persistence */
+inline arma::vec adamGvalue(arma::vec const &matrixVt, arma::mat const &matrixF, arma::mat const &rowvecW,
+                            char const &E, char const &T, char const &S,
+                            unsigned int const &nETS, unsigned int const &nNonSeasonal,
+                            unsigned int const &nSeasonal, unsigned int const &nArima,
+                            unsigned int const &nXreg, unsigned int const &nComponents,
+                            bool const &constant, arma::vec const &vectorG, double const error)
+{
+    arma::vec g(matrixVt.n_rows, arma::fill::ones);
+
+    if (nETS > 0)
+    {
+        // AZZ
+        switch (E)
+        {
+        case 'A':
+            // ANZ
+            switch (T)
+            {
+            case 'N':
+                switch (S)
+                {
+                case 'M':
+                    g(0) = 1 / as_scalar(rowvecW.cols(1, nSeasonal) * matrixVt.rows(1, nSeasonal));
+                    g.rows(1, nSeasonal).fill(1 / matrixVt(0));
+                    // // Explanatory variables
+                    // if(nComponents > (nETS)){
+                    //     /* g.rows(1,nSeasonal) = 1 / (1/g(1) +
+                    //      as_scalar(rowvecW.cols(nSeasonal,nComponents-1) * matrixVt.rows(nSeasonal,nComponents))); */
+                    //     g.rows(nETS,nComponents-1) = 1/matrixVt.rows(nETS,nComponents-1);
+                    // }
+                    break;
+                }
+                break;
+                // AAZ
+            case 'A':
+                switch (S)
+                {
+                case 'M':
+                    g.rows(0, 1) = g.rows(0, 1) / as_scalar(exp(rowvecW.cols(2, 2 + nSeasonal - 1) * log(matrixVt.rows(2, 2 + nSeasonal - 1))));
+                    g.rows(2, 2 + nSeasonal - 1).fill(1 / as_scalar(rowvecW.cols(0, 1) * matrixVt.rows(0, 1)));
+                    // // Explanatory variables
+                    // if(nComponents > (nETS)){
+                    //     /*g.rows(2,2+nSeasonal-1) = 1 / (1/g(1) +
+                    //       as_scalar(rowvecW.cols(nSeasonal,nComponents) * matrixVt.rows(nSeasonal,nComponents)));*/
+                    //     g.rows(nETS,nComponents-1) = 1/matrixVt.rows(nETS,nComponents-1);
+                    // }
+                    break;
+                }
+                break;
+                // AMZ
+            case 'M':
+                switch (S)
+                {
+                case 'N':
+                case 'A':
+                    g(1) = g(1) / matrixVt(0);
+                    break;
+                case 'M':
+                    g(0) = g(0) / as_scalar(rowvecW.cols(2, 2 + nSeasonal - 1) * matrixVt.rows(2, 2 + nSeasonal - 1));
+                    g(1) = g(1) / (matrixVt(0) * as_scalar(exp(rowvecW.cols(2, 2 + nSeasonal - 1) * log(matrixVt.rows(2, 2 + nSeasonal - 1)))));
+                    g.rows(2, 2 + nSeasonal - 1) = g.rows(2, 2 + nSeasonal - 1) / as_scalar(exp(rowvecW.cols(0, 1) * log(matrixVt.rows(0, 1))));
+                    break;
+                }
+                break;
+            }
+            break;
+            // MZZ
+        case 'M':
+            // MNZ
+            switch (T)
+            {
+            case 'N':
+                switch (S)
+                {
+                case 'N':
+                    g = matrixVt;
+                    break;
+                case 'A':
+                    g.rows(0, nSeasonal) = matrixVt.rows(0, nSeasonal);
+                    break;
+                case 'M':
+                    g = matrixVt;
+                    break;
+                }
+                break;
+                // MAZ
+            case 'A':
+                switch (S)
+                {
+                case 'N':
+                    g.rows(0, 1).fill(as_scalar(rowvecW.cols(0, 1) * matrixVt.rows(0, 1)));
+                    break;
+                case 'A':
+                    g.fill(as_scalar(rowvecW * matrixVt));
+                    // Explanatory variables
+                    // if(nComponents > (nETS)){
+                    //     g.rows(nETS,nComponents-1) = matrixVt.rows(nETS,nComponents-1);
+                    // }
+                    break;
+                case 'M':
+                    g.rows(0, 1).fill(as_scalar(rowvecW.cols(0, 1) * matrixVt.rows(0, 1)));
+                    g.rows(2, nComponents - 1) = matrixVt.rows(2, nComponents - 1);
+                    break;
+                }
+                break;
+                // MMZ
+            case 'M':
+                switch (S)
+                {
+                case 'N':
+                    g.rows(0, 1) = exp(matrixF.submat(0, 0, 1, 1) * log(matrixVt.rows(0, nNonSeasonal - 1)));
+                    break;
+                case 'A':
+                    g.rows(0, nComponents - 1).fill(as_scalar(exp(rowvecW.cols(0, 1) * log(matrixVt.rows(0, 1))) + rowvecW.cols(2, nETS - 1) * matrixVt.rows(2, nETS - 1)));
+                    // g(0) = g(0) / matrixVt(1);
+                    g(1) = g(1) / matrixVt(0);
+                    break;
+                case 'M':
+                    g.rows(0, 1) = exp(matrixF.submat(0, 0, 1, 1) * log(matrixVt.rows(0, nNonSeasonal - 1)));
+                    g.rows(2, nComponents - 1) = matrixVt.rows(2, nComponents - 1);
+                    break;
+                }
+                break;
+            }
+            break;
+        }
+    }
+
+    // Explanatory variables. Needed in order to update the parameters
+    if (nXreg > 0)
+    {
+        arma::vec vecWtxreg(1 / rowvecW.cols(nETS + nArima, nComponents - 1).t());
+        vecWtxreg.rows(find_nonfinite(vecWtxreg)).fill(0);
+        // If there are xreg components, make this: delta * log(1+e)/x from this: delta * e / x
+        switch (E)
+        {
+        case 'M':
+            g.rows(nETS + nArima, nComponents - 1) = vecWtxreg * log(1 + error) / error;
+            break;
+        case 'A':
+            g.rows(nETS + nArima, nComponents - 1) = vecWtxreg;
+            break;
+        }
+        g.rows(find_nonfinite(g)).fill(0);
+    }
+
+    // Do the multiplication in order to get the correct g(v) value
+    g = g % vectorG * error;
+
+    // If there are arima components, make sure that the g is correct for multiplicative error type
+    if (nArima > 0 && E == 'M')
+    {
+        g.rows(nETS, nETS + nArima - 1) =
+            adamFvalue(matrixVt, matrixF, E, T, S, nETS, nNonSeasonal, nSeasonal,
+                       nArima, nComponents, constant)
+                .rows(nETS, nETS + nArima - 1) %
+            (exp(vectorG.rows(nETS, nETS + nArima - 1) * log(1 + error)) - 1);
+    }
+
+    return g;
+}
+
+// /* # Function is needed for the renormalisation of seasonal components. It should be done seasonal-wise.*/
+// inline arma::mat normaliser(arma::mat Vt, int &obsall, unsigned int &maxlag, char const &S, char const &T){
+//
+//     unsigned int nComponents = Vt.n_rows;
+//     double meanseason = 0;
+//
+//     switch(S){
+//     case 'A':
+//         meanseason = mean(Vt.row(nComponents-1));
+//         Vt.row(nComponents-1) = Vt.row(nComponents-1) - meanseason;
+//         switch(T){
+//         case 'N':
+//         case 'A':
+//             Vt.row(0) = Vt.row(0) + meanseason;
+//             break;
+//         case 'M':
+//             Vt.row(0) = Vt.row(0) + meanseason / Vt.row(1);
+//             break;
+//         }
+//         break;
+//     case 'M':
+//         meanseason = exp(mean(log(Vt.row(nComponents-1))));
+//         Vt.row(nComponents-1) = Vt.row(nComponents-1) / meanseason;
+//         switch(T){
+//         case 'N':
+//         case 'M':
+//             Vt.row(0) = Vt.row(0) / meanseason;
+//             break;
+//         case 'A':
+//             Vt.row(0) = Vt.row(0) * meanseason;
+//             Vt.row(1) = Vt.row(1) * meanseason;
+//             break;
+//         }
+//         break;
+//     }
+//
+//     return(Vt);
+// }
+
+// from ssGeneral.h
+/* # Function returns multiplicative or additive error for scalar */
+inline double errorf(double const &yact, double &yfit, char const &E)
+{
+    if (E == 'A')
+    {
+        return yact - yfit;
+    }
+    else
+    {
+        if ((yact == 0) & (yfit == 0))
+        {
+            return 0;
+        }
+        else if ((yact != 0) & (yfit == 0))
+        {
+            // TODO: this should be the numpy infinity instead, replacing now to fix error
+            // message temporarily. TEMPORARILY!!!
+            return 9999999;
+        }
+        else
+        {
+            return (yact - yfit) / yfit;
+        }
+    }
+}
+
+/* # Function is needed to estimate the correct error for ETS when multisteps model selection with r(matvt) is sorted out. */
+inline arma::mat errorvf(arma::mat yact, arma::mat yfit, char const &E)
+{
+    if (E == 'A')
+    {
+        return yact - yfit;
+    }
+    else
+    {
+        yfit.elem(find(yfit == 0)).fill(1e-100);
+        return (yact - yfit) / yfit;
+    }
+}


### PR DESCRIPTION
Created a copy of the `adamGeneral.h` and `adamGeneral.cpp` to experiment with creating pybind11 wrappers for the `adamFitter` function. In these copies I replaced RcppArmadillo with armadillo and Rcpp with pybind11 and carma. 

The package successfully compiles but I haven't tested if it really works yet, we need to come up with some sensible defaults for testing it.

But we can import it in python now which I consider great success! 
![image](https://github.com/config-i1/smooth/assets/64217214/e92a166a-2f9a-4b4d-a983-07b0a6e7fa4b)

