### PR TITLE
fix usage of 'traditional' instead of 'usual' for function adam

### DIFF
--- a/R/adam.R
+++ b/R/adam.R
@@ -241,7 +241,7 @@ utils::globalVariables(c("adamFitted","algorithm","arEstimate","arOrders","arReq
 #' procedure.
 #' @param bounds The type of bounds for the persistence to use in the model
 #' estimation. Can be either \code{admissible} - guaranteeing the stability of the
-#' model, \code{traditional} - restricting the values with (0, 1) or \code{none} - no
+#' model, \code{usual} - restricting the values with (0, 1) or \code{none} - no
 #' restrictions (potentially dangerous).
 #' @param regressors The variable defines what to do with the provided explanatory
 #' variables:

--- a/R/adamGeneral.R
+++ b/R/adamGeneral.R
@@ -4,7 +4,7 @@ parametersChecker <- function(data, model, lags, formulaToUse, orders, constant=
                               distribution=c("default","dnorm","dlaplace","dalaplace","ds","dgnorm",
                                              "dlnorm","dinvgauss","dgamma"),
                               loss, h, holdout, occurrence,
-                              ic=c("AICc","AIC","BIC","BICc"), bounds=c("traditional","usual","admissible","none"),
+                              ic=c("AICc","AIC","BIC","BICc"), bounds=c("usual","admissible","none"),
                               regressors, yName,
                               silent, modelDo, ParentEnvironment,
                               ellipsis, fast=FALSE){

--- a/man/adam.Rd
+++ b/man/adam.Rd
@@ -229,7 +229,7 @@ procedure.}
 
 \item{bounds}{The type of bounds for the persistence to use in the model
 estimation. Can be either \code{admissible} - guaranteeing the stability of the
-model, \code{traditional} - restricting the values with (0, 1) or \code{none} - no
+model, \code{usual} - restricting the values with (0, 1) or \code{none} - no
 restrictions (potentially dangerous).}
 
 \item{silent}{Specifies, whether to provide the progress of the function or not.

--- a/vignettes/adam.Rmd
+++ b/vignettes/adam.Rmd
@@ -320,7 +320,7 @@ The same functionality is supported with ARIMA, so you can have, for example, AR
 testModel <- adam(BJData, "NNN", h=18, silent=FALSE, holdout=TRUE, regressors="select", orders=c(0,1,1))
 ```
 
-The two models might differ because they have different initialisation in the optimiser and different bounds for parameters (ARIMA relies on invertibility condition, while ETS does the traditional (0,1) bounds by default). It is possible to make them identical if the number of iterations is increased and the initial parameters are the same. Here is an example of what happens, when the two models have exactly the same parameters:
+The two models might differ because they have different initialisation in the optimiser and different bounds for parameters (ARIMA relies on invertibility condition, while ETS does the usual (0,1) bounds by default). It is possible to make them identical if the number of iterations is increased and the initial parameters are the same. Here is an example of what happens, when the two models have exactly the same parameters:
 
 ```{r}
 BJData <- BJData[,c("y",names(testModel$initial$xreg))];


### PR DESCRIPTION
While examining the code for the adam function in adam.R, I discovered that it is implemented with the parameter 'bounds=c("usual","admissible","none")'. However, in the documentation for the bounds parameter '@param bounds', bounds are described as '...traditional - restricting the values within (0, 1)...'. 

In the 'adamGeneral.R' file, bounds are implemented as 'bounds=c("traditional","usual","admissible","none")'. However, when bounds="traditional", line 2483 'bounds <- match.arg(bounds,c("usual","admissible","none"))' throws an error.

Additionally, while reviewing the examples in 'adam.Rmd', 'traditional' was used once more, where 'usual' would provide better clarity.