### PR TITLE
Switch from deprecated arma::is_finite to std::isfinite

### DIFF
--- a/src/ssGeneral.cpp
+++ b/src/ssGeneral.cpp
@@ -17,7 +17,7 @@ double cdf(arma::vec const &vecYt, arma::vec const &vecYfit, double const &error
             CFbuffer = log(R::pnorm(ceil(vecYt(i)), vecYfit(i), errorSD, 1, 0) - R::pnorm(ceil(vecYt(i))-1, vecYfit(i), errorSD, 1, 0));
             // If CF is infinite, then this means that P(x<X)=1 for both cases.
             // This is automatically transfered into log(1)
-            if(arma::is_finite(CFbuffer)){
+            if(std::isfinite(CFbuffer)){
                 CF += CFbuffer;
             }
         }
@@ -25,7 +25,7 @@ double cdf(arma::vec const &vecYt, arma::vec const &vecYfit, double const &error
     else{
         for(int i=0; i<obs; ++i){
             CFbuffer = log(R::plnorm(ceil(vecYt(i)), log(vecYfit(i)), errorSD, 1, 0) - R::plnorm(ceil(vecYt(i))-1, log(vecYfit(i)), errorSD, 1, 0));
-            if(arma::is_finite(CFbuffer)){
+            if(std::isfinite(CFbuffer)){
                 CF += CFbuffer;
             }
         }


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be very simple, and yours is one of them -- in fact it is just two statements. In the patch below we simply update this as now required by Armadillo 15.0.x.  Now, your repo seems to have more `arma::is_finite()` calls and you may need to consider changing those too---but they don't appear to be 'hit' when building the R package.

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters.
