### PR TITLE
Fixes in the simulated interval construction

### DIFF
--- a/R/adam.R
+++ b/R/adam.R
@@ -8026,12 +8026,20 @@ forecast.adam <- function(object, h=10, newdata=NULL, occurrence=NULL,
     if(interval=="simulated"){
         arrVt <- array(NA, c(componentsNumberETS+componentsNumberARIMA+xregNumber+constantRequired, h+lagsModelMax, nsim));
         arrVt[,1:lagsModelMax,] <- rep(matVt,nsim);
-        # Number of degrees of freedom to de-bias scales
-        df <- (nobs(object, all=FALSE)-nparam(object));
+
+        #### This is scale, not sigma, which is why we use the one from the model!
+        # Number of degrees of freedom to de-bias scales.
+        # Scale parameter is not needed for de-bias itself.
+        nParam <- nparam(object);
+        if(!is.null(object$loss) && object$loss=="likelihood"){
+            nParam <- nParam - object$nParam[1,4];
+        }
+        df <- nobs(object, all=FALSE) - nParam;
         # If the sample is too small, then use biased estimator
         if(df<=0){
             df[] <- nobs(object, all=FALSE);
         }
+
         # If scale model is included, produce forecasts
         if(is.scale(object$scale)){
             # as.vector is needed to declass the mean.

--- a/python/src/smooth/adam_general/core/adam.py
+++ b/python/src/smooth/adam_general/core/adam.py
@@ -3130,6 +3130,7 @@ class ADAM:
                     "prepared": prepared,
                     "explanatory_dict": self._explanatory,
                     "constants_dict": self._constant,
+                    "n_param_estimated": result["adam_estimated"]["n_param_estimated"],
                 }
             )
 

--- a/python/src/smooth/adam_general/core/forecaster/forecaster.py
+++ b/python/src/smooth/adam_general/core/forecaster/forecaster.py
@@ -5,6 +5,8 @@ import pandas as pd
 
 # Note: adam_cpp instance is passed to functions that need C++ integration
 # The adamCore object is created in architector() and passed through the pipeline
+from smooth.adam_general.core.utils.n_param import NParam
+
 from ._helpers import (
     _prepare_lookup_table,
     _prepare_matrices_for_forecast,
@@ -926,6 +928,27 @@ def forecaster_combined(
 
         general_dict_copy = copy.deepcopy(general_dict)
 
+        # Use the sub-model's own distribution (stored by preparator at fit time).
+        # Without this, A-error sub-models would inherit the best (M-error) model's
+        # "dgamma" distribution, causing wrong error generation and wider intervals.
+        sub_dist = prepared.get("distribution")
+        if sub_dist:
+            general_dict_copy["distribution"] = sub_dist
+
+        # Build per-sub-model NParam so simulation uses df = T - k_i, not weighted_k.
+        n_est_i = model_info.get("n_param_estimated", 0)
+        n_param_sub = NParam()
+        n_param_sub.estimated["internal"] = n_est_i
+        if general_dict_copy.get("loss") == "likelihood":
+            n_param_sub.estimated["scale"] = 1
+        n_param_sub.update_totals()
+        general_dict_copy["n_param"] = n_param_sub
+
+        # Build per-sub-model params_info for sigma() in approximate intervals.
+        # Combined model stores [[0],[0]] which would cause IndexError in sigma().
+        n_scale = 1 if general_dict_copy.get("loss") == "likelihood" else 0
+        sub_params_info = [[n_est_i, n_scale, n_est_i + n_scale], [0]]
+
         model_forecast = forecaster(
             model_prepared=prepared,
             observations_dict=observations_dict,
@@ -942,7 +965,7 @@ def forecaster_combined(
                 "constants_dict",
                 {"constant_required": False},
             ),
-            params_info=params_info,
+            params_info=sub_params_info,
             adam_cpp=adam_cpp,
             interval=interval,
             level=level,

--- a/python/src/smooth/adam_general/core/forecaster/forecaster.py
+++ b/python/src/smooth/adam_general/core/forecaster/forecaster.py
@@ -250,8 +250,10 @@ def _generate_point_forecasts(
         mat_wt[:, xreg_start:xreg_end] = new_xreg
 
     # Prepare data for adam_forecaster
+    # Must copy: adam_cpp.forecast() modifies profilesRecent in-place via carma memory
+    # sharing, advancing the profile from T to T+h. Copy prevents corruption.
     profiles_recent_table = np.asfortranarray(
-        model_prepared["profiles_recent_table"], dtype=np.float64
+        model_prepared["profiles_recent_table"].copy(), dtype=np.float64
     )
     index_lookup_table = np.asfortranarray(lookup, dtype=np.uint64)
 

--- a/python/src/smooth/adam_general/core/forecaster/intervals.py
+++ b/python/src/smooth/adam_general/core/forecaster/intervals.py
@@ -604,8 +604,8 @@ def generate_simulation_interval(
     if general_dict.get("cumulative", False):
         y_forecast_sim = np.mean(np.sum(y_simulated, axis=0))
         cum_sums = np.sum(y_simulated, axis=0)
-        y_lower = np.quantile(cum_sums, level_low).reshape(1, n_levels)
-        y_upper = np.quantile(cum_sums, level_up).reshape(1, n_levels)
+        y_lower = np.nanquantile(cum_sums, level_low).reshape(1, n_levels)
+        y_upper = np.nanquantile(cum_sums, level_up).reshape(1, n_levels)
     else:
         # 10. Calculate quantiles for each horizon
         y_lower = np.zeros((h, n_levels))
@@ -617,8 +617,8 @@ def generate_simulation_interval(
             # (matches R commit 7d4d3736)
             y_forecast_sim[i] = np.mean(y_simulated[i, :])
 
-            y_lower[i, :] = np.quantile(y_simulated[i, :], level_low)
-            y_upper[i, :] = np.quantile(y_simulated[i, :], level_up)
+            y_lower[i, :] = np.nanquantile(y_simulated[i, :], level_low)
+            y_upper[i, :] = np.nanquantile(y_simulated[i, :], level_up)
 
     # 11. Convert to relative form (like parametric intervals)
     # Use (h, 1) broadcasting for 2D y_lower/y_upper
@@ -627,23 +627,22 @@ def generate_simulation_interval(
         y_lower = y_lower - pred_col
         y_upper = y_upper - pred_col
     else:
-        sim_col = y_forecast_sim.reshape(-1, 1)
-        y_lower = np.where(sim_col != 0, y_lower / sim_col, 0)
-        y_upper = np.where(sim_col != 0, y_upper / sim_col, 0)
+        pred_col = predictions.reshape(-1, 1)
+        y_lower = np.where(pred_col != 0, y_lower / pred_col, 0)
+        y_upper = np.where(pred_col != 0, y_upper / pred_col, 0)
 
     # 12. Final combination with forecasts (same as parametric)
-    replace_val = 0.0 if e_type == "A" else 1.0
+    replace_val = 0.0  # both A and M: R sets NaN to 0 (yLower[is.nan(yLower)] <- 0)
     y_lower_final = np.where(np.isnan(y_lower), replace_val, y_lower)
     y_upper_final = np.where(np.isnan(y_upper), replace_val, y_upper)
 
+    pred_col = predictions.reshape(-1, 1)
     if e_type == "A":
-        pred_col = predictions.reshape(-1, 1)
         y_lower_final = pred_col + y_lower_final
         y_upper_final = pred_col + y_upper_final
     else:
-        sim_col = y_forecast_sim.reshape(-1, 1)
-        y_lower_final = sim_col * y_lower_final
-        y_upper_final = sim_col * y_upper_final
+        y_lower_final = pred_col * y_lower_final
+        y_upper_final = pred_col * y_upper_final
 
     scenarios_out = y_simulated if general_dict.get("scenarios", False) else None
     return y_lower_final, y_upper_final, scenarios_out, y_forecast_sim

--- a/python/src/smooth/adam_general/core/utils/var_covar.py
+++ b/python/src/smooth/adam_general/core/utils/var_covar.py
@@ -171,7 +171,7 @@ def sigma(observations_dict, params_info, general, prepared_model):
     params_number = params_info[0][-1]
 
     # In case of likelihood, scale is not calculated towards parameters for variance
-    if general["loss"] == "likelihood":
+    if general["loss"] == "likelihood" and len(params_info[0]) > 1:
         params_number = params_number - params_info[0][1]
 
     vals = observations_dict["obs_in_sample"] - params_number


### PR DESCRIPTION
## What issue does this PR fix?

Did not open the issue. The problem was that the simulated interval in Python differed substantially from the one in R. This was because of the modification of the profile that was then carried over to the simulations. Now we copy it not to mess things up.

While investigating, I also found that the scale for simulations in forecast.adam() in R had the wrong degrees of freedom. This is now fixed.

## Language

- [ ] R
- [ ] Python
- [x] Both

## Package version

The latest versions

## Development environment

Ubuntu 24.04

## AI assistance

- [x] AI was used in the creation of this PR

**If yes — how was AI used?**

Claude did the investigations in the Python code and found the bug.