### PR TITLE
nit: rename kargs to kwargs everywhere

### DIFF
--- a/python/ADAM_API_REFERENCE.md
+++ b/python/ADAM_API_REFERENCE.md
@@ -64,7 +64,7 @@ Complete reference for `smooth.adam_general.core.adam.ADAM`.
 | `nlopt_initial` | `dict \| None` | `None` | Initial values for NLopt optimizer |
 | `nlopt_upper` | `dict \| None` | `None` | Upper bounds for optimizer |
 | `nlopt_lower` | `dict \| None` | `None` | Lower bounds for optimizer |
-| `nlopt_kargs` | `dict \| None` | `None` | Extra NLopt options: `print_level`, `xtol_rel`, `xtol_abs`, `ftol_rel`, `ftol_abs`, `algorithm` |
+| `nlopt_kwargs` | `dict \| None` | `None` | Extra NLopt options: `print_level`, `xtol_rel`, `xtol_abs`, `ftol_rel`, `ftol_abs`, `algorithm` |
 
 ### Other
 

--- a/python/docs/index.rst
+++ b/python/docs/index.rst
@@ -144,7 +144,7 @@ Optimization Settings
 ---------------------
 
 The ADAM and ES classes use the NLopt library for parameter optimization. You can
-customize the optimization behavior via the ``nlopt_kargs`` parameter:
+customize the optimization behavior via the ``nlopt_kwargs`` parameter:
 
 .. code-block:: python
 
@@ -152,7 +152,7 @@ customize the optimization behavior via the ``nlopt_kargs`` parameter:
 
    model = ADAM(
        model="AAN",
-       nlopt_kargs={
+       nlopt_kwargs={
            "print_level": 1,        # Print optimization progress
            "xtol_rel": 1e-8,        # Relative parameter tolerance
            "algorithm": "NLOPT_LN_SBPLX"  # Use Subplex algorithm

--- a/python/src/smooth/adam_general/core/adam.py
+++ b/python/src/smooth/adam_general/core/adam.py
@@ -662,7 +662,7 @@ class ADAM:
         nlopt_initial: Optional[Dict[str, Any]] = None,
         nlopt_upper: Optional[Dict[str, Any]] = None,
         nlopt_lower: Optional[Dict[str, Any]] = None,
-        nlopt_kargs: Optional[Dict[str, Any]] = None,
+        nlopt_kwargs: Optional[Dict[str, Any]] = None,
         # specific to losses or distributions
         reg_lambda: Optional[float] = None,
         gnorm_shape: Optional[float] = None,
@@ -768,7 +768,7 @@ class ADAM:
             Upper bounds for optimization parameters for NLopt solver.
         nlopt_lower : Optional[Dict[str, Any]], default=None
             Lower bounds for optimization parameters for NLopt solver.
-        nlopt_kargs : Optional[Dict[str, Any]], default=None
+        nlopt_kwargs : Optional[Dict[str, Any]], default=None
             Additional keyword arguments for optimization. Supported keys:
 
             - ``print_level`` (int): Verbosity level for optimization progress
@@ -794,7 +794,7 @@ class ADAM:
 
             Example::
 
-                model = ADAM(model="AAN", nlopt_kargs={
+                model = ADAM(model="AAN", nlopt_kwargs={
                     "print_level": 1,
                     "xtol_rel": 1e-8,
                     "algorithm": "NLOPT_LN_SBPLX"
@@ -843,7 +843,7 @@ class ADAM:
         self.nlopt_initial = nlopt_initial
         self.nlopt_upper = nlopt_upper
         self.nlopt_lower = nlopt_lower
-        self.nlopt_kargs = nlopt_kargs
+        self.nlopt_kwargs = nlopt_kwargs
         self.reg_lambda = reg_lambda
         self.gnorm_shape = gnorm_shape
         self.smoother = smoother
@@ -863,11 +863,11 @@ class ADAM:
             self.lambda_param = lambda_param
 
         # Handle 'print_level' from kwargs for convenience
-        # Users can pass print_level=1 directly or via nlopt_kargs={'print_level': 1}
+        # Users can pass print_level=1 directly or via nlopt_kwargs={'print_level': 1}
         if "print_level" in kwargs:
-            if self.nlopt_kargs is None:
-                self.nlopt_kargs = {}
-            self.nlopt_kargs["print_level"] = kwargs["print_level"]
+            if self.nlopt_kwargs is None:
+                self.nlopt_kwargs = {}
+            self.nlopt_kwargs["print_level"] = kwargs["print_level"]
 
         # Store profile parameters
         self.profiles_recent_provided = profiles_recent_provided
@@ -3369,7 +3369,7 @@ class ADAM:
             else:
                 other_value = float(self.gnorm_shape)
 
-            nlopt_params = self.nlopt_kargs if self.nlopt_kargs else {}
+            nlopt_params = self.nlopt_kwargs if self.nlopt_kwargs else {}
             self._adam_estimated = estimator(
                 general_dict=self._general,
                 model_type_dict=self._model_type,
@@ -3544,7 +3544,7 @@ class ADAM:
             initials_results=self._initials,
             criterion=self._general["ic"],
             silent=self.verbose == 0,
-            nlopt_kargs=self.nlopt_kargs,
+            nlopt_kwargs=self.nlopt_kwargs,
             smoother=self.smoother,
         )
         # print(self._adam_selected)

--- a/python/src/smooth/adam_general/core/auto_om.py
+++ b/python/src/smooth/adam_general/core/auto_om.py
@@ -72,7 +72,7 @@ class AutoOM:
         ic: Literal["AIC", "AICc", "BIC", "BICc"] = "AICc",
         bounds: Literal["usual", "admissible", "none"] = "usual",
         verbose: int = 0,
-        nlopt_kargs: Optional[Dict[str, Any]] = None,
+        nlopt_kwargs: Optional[Dict[str, Any]] = None,
         ets: Literal["conventional", "adam"] = "conventional",
         arima_select: bool = False,
         ar_order: Union[int, List[int]] = 3,
@@ -101,7 +101,7 @@ class AutoOM:
         self.ic = ic
         self.bounds = bounds
         self.verbose = verbose
-        self.nlopt_kargs = nlopt_kargs
+        self.nlopt_kwargs = nlopt_kwargs
         if ets not in ("conventional", "adam"):
             raise ValueError(f"Invalid ets: {ets!r}. Must be 'conventional' or 'adam'.")
         self.ets = ets
@@ -123,7 +123,7 @@ class AutoOM:
             ic=self.ic,
             bounds=self.bounds,
             verbose=self.verbose,
-            nlopt_kargs=self.nlopt_kargs,
+            nlopt_kwargs=self.nlopt_kwargs,
         )
 
     def _build_candidate(self, occ: str) -> Union[OM, OMG]:

--- a/python/src/smooth/adam_general/core/estimator/selector.py
+++ b/python/src/smooth/adam_general/core/estimator/selector.py
@@ -145,7 +145,7 @@ def _estimate_model(
     initials_results,
     occurrence_dict,
     components_dict,
-    nlopt_kargs=None,
+    nlopt_kwargs=None,
     smoother="global",
 ):
     """
@@ -203,7 +203,7 @@ def _estimate_model(
         occurrence_dict=occurrence_dict,
         phi_dict=phi_dict_temp,
         components_dict=components_dict,
-        **(nlopt_kargs or {}),
+        **(nlopt_kwargs or {}),
         smoother=smoother,
     )
 
@@ -240,7 +240,7 @@ def _run_branch_and_bound(
     pool_trends,
     check_seasonal,
     check_trend,
-    nlopt_kargs=None,
+    nlopt_kwargs=None,
     smoother="global",
     silent=False,
 ):
@@ -365,7 +365,7 @@ def _run_branch_and_bound(
             initials_results,
             occurrence_dict,
             components_dict,
-            nlopt_kargs=nlopt_kargs,
+            nlopt_kwargs=nlopt_kwargs,
             smoother=smoother,
         )
 
@@ -548,7 +548,7 @@ def _estimate_all_models(
     occurrence_dict,
     components_dict,
     silent=False,
-    nlopt_kargs=None,
+    nlopt_kwargs=None,
     # Pre-computed results from branch-and-bound
     precomputed_results=None,
     precomputed_models=None,
@@ -668,7 +668,7 @@ def _estimate_all_models(
             occurrence_dict=occurrence_dict,
             phi_dict=phi_dict_temp,
             components_dict=components_dict,
-            **(nlopt_kargs or {}),
+            **(nlopt_kwargs or {}),
             smoother=smoother,
         )
         results[j]["IC"] = ic_function(
@@ -701,7 +701,7 @@ def selector(
     initials_results,
     criterion="AICc",
     silent=False,
-    nlopt_kargs=None,
+    nlopt_kwargs=None,
     smoother="global",
 ):
     """
@@ -1005,7 +1005,7 @@ def selector(
                     pool_trends,
                     check_seasonal,
                     check_trend,
-                    nlopt_kargs=nlopt_kargs,
+                    nlopt_kwargs=nlopt_kwargs,
                     smoother=smoother,
                     silent=silent,
                 )
@@ -1053,7 +1053,7 @@ def selector(
         occurrence_dict,
         components_dict,
         silent,
-        nlopt_kargs=nlopt_kargs,
+        nlopt_kwargs=nlopt_kwargs,
         precomputed_results=bb_results,
         precomputed_models=bb_models_tested,
         smoother=smoother,

--- a/python/src/smooth/adam_general/core/om.py
+++ b/python/src/smooth/adam_general/core/om.py
@@ -394,7 +394,7 @@ class OM(ADAM):
                         "ic",
                         "bounds",
                         "verbose",
-                        "nlopt_kargs",
+                        "nlopt_kwargs",
                     )
                 }
             )
@@ -430,7 +430,7 @@ class OM(ADAM):
         ic: Literal["AIC", "AICc", "BIC", "BICc"] = "AICc",
         bounds: Literal["usual", "admissible", "none"] = "usual",
         verbose: int = 0,
-        nlopt_kargs: Optional[Dict[str, Any]] = None,
+        nlopt_kwargs: Optional[Dict[str, Any]] = None,
         ets: Literal["conventional", "adam"] = "conventional",
         **kwargs,
     ) -> None:
@@ -496,7 +496,7 @@ class OM(ADAM):
             verbose=verbose,
             h=h,
             holdout=holdout,
-            nlopt_kargs=nlopt_kargs,
+            nlopt_kwargs=nlopt_kwargs,
             ets=ets,
             reg_lambda=reg_lambda,
             # ``reg_lambda`` is the user-facing name on OM (mirrors ADAM's
@@ -620,7 +620,7 @@ class OM(ADAM):
                 arma=getattr(self, "arma", None),
                 regressors=getattr(self, "regressors", "use"),
                 verbose=getattr(self, "verbose", 0),
-                nlopt_kargs=getattr(self, "nlopt_kargs", None),
+                nlopt_kwargs=getattr(self, "nlopt_kwargs", None),
             ).fit(y, X)
 
         self._start_time = time.time()
@@ -946,16 +946,16 @@ class OM(ADAM):
             other_value=2.0,
         )
 
-        # Optimisation knobs (subset of nlopt_kargs we care about for OM)
-        kargs = self.nlopt_kargs or {}
+        # Optimisation knobs (subset of nlopt_kwargs we care about for OM)
+        kwargs = self.nlopt_kwargs or {}
 
-        # Respect user-supplied B / lb / ub from nlopt_kargs (mirrors R's
+        # Respect user-supplied B / lb / ub from nlopt_kwargs (mirrors R's
         # adam_checkOptimizer + adam.R:1229-1361 pattern). Named B is supplied
         # as a dict (parameter-name -> value); array-like B is assigned
         # positionally. lb / ub fall back to b_values only when not provided.
-        user_B = kargs.get("B")  # noqa: N806
-        user_lb = kargs.get("lb")
-        user_ub = kargs.get("ub")
+        user_B = kwargs.get("B")  # noqa: N806
+        user_lb = kwargs.get("lb")
+        user_ub = kwargs.get("ub")
 
         B = np.asarray(b_values["B"], dtype=float)  # noqa: N806
         names = b_values.get("names")
@@ -986,12 +986,12 @@ class OM(ADAM):
         ar_polynomial_matrix, ma_polynomial_matrix = _setup_arima_polynomials(
             self._model_type, self._arima, self._lags_model
         )
-        algorithm = kargs.get("algorithm", "NLOPT_LN_NELDERMEAD")
-        xtol_rel = kargs.get("xtol_rel", 1e-6)
-        xtol_abs = kargs.get("xtol_abs", 1e-8)
-        ftol_rel = kargs.get("ftol_rel", 1e-8)
-        ftol_abs = kargs.get("ftol_abs", 0)
-        maxeval = kargs.get("maxeval", len(B) * 40)
+        algorithm = kwargs.get("algorithm", "NLOPT_LN_NELDERMEAD")
+        xtol_rel = kwargs.get("xtol_rel", 1e-6)
+        xtol_abs = kwargs.get("xtol_abs", 1e-8)
+        ftol_rel = kwargs.get("ftol_rel", 1e-8)
+        ftol_abs = kwargs.get("ftol_abs", 0)
+        maxeval = kwargs.get("maxeval", len(B) * 40)
         if self._explanatory.get("xreg_model"):
             maxeval = max(maxeval, max(1000, len(B) * 100))
 

--- a/python/src/smooth/adam_general/core/omg.py
+++ b/python/src/smooth/adam_general/core/omg.py
@@ -107,7 +107,7 @@ class OMG:
         ic: Literal["AIC", "AICc", "BIC", "BICc"] = "AICc",
         bounds: Literal["usual", "admissible", "none"] = "usual",
         verbose: int = 0,
-        nlopt_kargs: Optional[Dict[str, Any]] = None,
+        nlopt_kwargs: Optional[Dict[str, Any]] = None,
         ets: Literal["conventional", "adam"] = "conventional",
     ) -> None:
         # Accept callable for user-defined custom loss (same API as ADAM,
@@ -152,7 +152,7 @@ class OMG:
         self.ic = ic
         self.bounds = bounds
         self.verbose = verbose
-        self.nlopt_kargs = nlopt_kargs
+        self.nlopt_kwargs = nlopt_kwargs
         if ets not in ("conventional", "adam"):
             raise ValueError(f"Invalid ets: {ets!r}. Must be 'conventional' or 'adam'.")
         self.ets = ets
@@ -677,7 +677,7 @@ class OMG:
             ic=self.ic,
             bounds=self.bounds,
             verbose=0,
-            nlopt_kargs=self.nlopt_kargs,
+            nlopt_kwargs=self.nlopt_kwargs,
             ets=self.ets,
         )
 
@@ -863,7 +863,7 @@ class OMG:
             verbose=self.verbose,
             holdout=self.holdout,
             h=self.h,
-            nlopt_kargs=self.nlopt_kargs,
+            nlopt_kwargs=self.nlopt_kwargs,
             ets=self.ets,
         )
         scaffold._start_time = time.time()
@@ -931,14 +931,14 @@ class OMG:
         self._names_a = list(b_a.get("names") or [])
         self._names_b = list(b_b.get("names") or [])
 
-        # Respect user-supplied B / lb / ub from nlopt_kargs. B is the JOINT
+        # Respect user-supplied B / lb / ub from nlopt_kwargs. B is the JOINT
         # vector spanning A-side then B-side. dict-keyed names are matched
         # against suffixed names ("alpha_A", "alpha_B", ...); array-like B is
         # assigned positionally. lb / ub override positionally.
-        kargs = self.nlopt_kargs or {}
-        user_B = kargs.get("B")  # noqa: N806
-        user_lb = kargs.get("lb")
-        user_ub = kargs.get("ub")
+        kwargs = self.nlopt_kwargs or {}
+        user_B = kwargs.get("B")  # noqa: N806
+        user_lb = kwargs.get("lb")
+        user_ub = kwargs.get("ub")
 
         names_a = b_a.get("names") or []
         names_b = b_b.get("names") or []
@@ -979,13 +979,13 @@ class OMG:
         )
 
     def _optimise(self, B_used, lb, ub, side_a, side_b, n_params_a):
-        kargs = self.nlopt_kargs or {}
-        algorithm = kargs.get("algorithm", "NLOPT_LN_NELDERMEAD")
-        xtol_rel = kargs.get("xtol_rel", 1e-6)
-        xtol_abs = kargs.get("xtol_abs", 1e-8)
-        ftol_rel = kargs.get("ftol_rel", 1e-8)
-        ftol_abs = kargs.get("ftol_abs", 0)
-        maxeval = kargs.get("maxeval", len(B_used) * 40)
+        kwargs = self.nlopt_kwargs or {}
+        algorithm = kwargs.get("algorithm", "NLOPT_LN_NELDERMEAD")
+        xtol_rel = kwargs.get("xtol_rel", 1e-6)
+        xtol_abs = kwargs.get("xtol_abs", 1e-8)
+        ftol_rel = kwargs.get("ftol_rel", 1e-8)
+        ftol_abs = kwargs.get("ftol_abs", 0)
+        maxeval = kwargs.get("maxeval", len(B_used) * 40)
         nlopt_algorithm = getattr(
             nlopt, algorithm.replace("NLOPT_", ""), nlopt.LN_NELDERMEAD
         )
@@ -1034,7 +1034,7 @@ class OMG:
         # own B — otherwise their B is the authoritative starting point.
         # Mirrors the failsafe in R/omg.R: all params 0.001 with the two
         # leading alphas (A-side and B-side) bumped to 0.01.
-        user_B_supplied = kargs.get("B") is not None  # noqa: N806
+        user_B_supplied = kwargs.get("B") is not None  # noqa: N806
         if not user_B_supplied and (not np.isfinite(cf_value) or cf_value >= 1e300):
             B_used[:] = 0.001
             if len(B_used) > 0:
@@ -1397,5 +1397,5 @@ def _build_omg_from_om_kwargs(**om_kwargs) -> OMG:
         ic=om_kwargs.pop("ic", "AICc"),
         bounds=om_kwargs.pop("bounds", "usual"),
         verbose=om_kwargs.pop("verbose", 0),
-        nlopt_kargs=om_kwargs.pop("nlopt_kargs", None),
+        nlopt_kwargs=om_kwargs.pop("nlopt_kwargs", None),
     )

--- a/python/tests/test_nlopt_kwargs.py
+++ b/python/tests/test_nlopt_kwargs.py
@@ -1,5 +1,5 @@
 """
-Tests to verify that nlopt_kargs parameters flow correctly through to NLopt.
+Tests to verify that nlopt_kwargs parameters flow correctly through to NLopt.
 
 Covers both the direct estimation path (fixed model) and the model-selection
 path (ZXZ, ZZZ), where a bug previously caused TypeError for unknown kwargs.
@@ -16,27 +16,27 @@ _t = np.arange(48)
 Y = 100 + 0.5 * _t + 8 * np.sin(2 * np.pi * _t / 12) + np.random.randn(48) * 3
 
 
-class TestNloptKargsSingleModel:
-    """nlopt_kargs on fixed (non-selection) models."""
+class TestNloptKwargsSingleModel:
+    """nlopt_kwargs on fixed (non-selection) models."""
 
     def test_maxeval(self):
-        model = ADAM(model="ANN", lags=[1], nlopt_kargs={"maxeval": 5})
+        model = ADAM(model="ANN", lags=[1], nlopt_kwargs={"maxeval": 5})
         model.fit(Y)
         assert hasattr(model, "loglik")
 
     def test_print_level(self):
-        model = ADAM(model="ANN", lags=[1], nlopt_kargs={"print_level": 0})
+        model = ADAM(model="ANN", lags=[1], nlopt_kwargs={"print_level": 0})
         model.fit(Y)
         assert hasattr(model, "loglik")
 
     def test_xtol_rel(self):
-        model = ADAM(model="ANN", lags=[1], nlopt_kargs={"xtol_rel": 1e-4})
+        model = ADAM(model="ANN", lags=[1], nlopt_kwargs={"xtol_rel": 1e-4})
         model.fit(Y)
         assert hasattr(model, "loglik")
 
     def test_algorithm_sbplx(self):
         model = ADAM(
-            model="ANN", lags=[1], nlopt_kargs={"algorithm": "NLOPT_LN_SBPLX"}
+            model="ANN", lags=[1], nlopt_kwargs={"algorithm": "NLOPT_LN_SBPLX"}
         )
         model.fit(Y)
         assert hasattr(model, "loglik")
@@ -45,14 +45,14 @@ class TestNloptKargsSingleModel:
         model = ADAM(
             model="AAN",
             lags=[1],
-            nlopt_kargs={"maxeval": 10, "print_level": 0, "xtol_rel": 1e-4},
+            nlopt_kwargs={"maxeval": 10, "print_level": 0, "xtol_rel": 1e-4},
         )
         model.fit(Y)
         assert hasattr(model, "loglik")
 
     def test_maxeval_affects_loglik(self):
         """Tight maxeval (very few evals) should give a different loglik than default."""
-        m_tight = ADAM(model="ANN", lags=[1], nlopt_kargs={"maxeval": 2})
+        m_tight = ADAM(model="ANN", lags=[1], nlopt_kwargs={"maxeval": 2})
         m_tight.fit(Y)
 
         m_full = ADAM(model="ANN", lags=[1])
@@ -62,15 +62,15 @@ class TestNloptKargsSingleModel:
         assert m_tight.loglik != m_full.loglik
 
 
-class TestNloptKargsModelSelection:
-    """nlopt_kargs on model-selection models (ZXZ, ZZZ)."""
+class TestNloptKwargsModelSelection:
+    """nlopt_kwargs on model-selection models (ZXZ, ZZZ)."""
 
     def test_maxeval_with_zxz(self):
         """maxeval must not raise TypeError in the selection path — original bug."""
         model = ADAM(
             model="ZXZ",
             lags=[1, 12],
-            nlopt_kargs={"maxeval": 2},
+            nlopt_kwargs={"maxeval": 2},
         )
         model.fit(Y)  # must not raise TypeError
         assert hasattr(model, "loglik")
@@ -79,7 +79,7 @@ class TestNloptKargsModelSelection:
         model = ADAM(
             model="ZZZ",
             lags=[1, 12],
-            nlopt_kargs={"maxeval": 2},
+            nlopt_kwargs={"maxeval": 2},
         )
         model.fit(Y)
         assert hasattr(model, "loglik")
@@ -88,7 +88,7 @@ class TestNloptKargsModelSelection:
         model = ADAM(
             model="ZXZ",
             lags=[1, 12],
-            nlopt_kargs={"algorithm": "NLOPT_LN_SBPLX"},
+            nlopt_kwargs={"algorithm": "NLOPT_LN_SBPLX"},
         )
         model.fit(Y)
         assert hasattr(model, "loglik")
@@ -97,14 +97,14 @@ class TestNloptKargsModelSelection:
         model = ADAM(
             model="ZXZ",
             lags=[1, 12],
-            nlopt_kargs={"maxeval": 2, "xtol_rel": 1e-4},
+            nlopt_kwargs={"maxeval": 2, "xtol_rel": 1e-4},
         )
         model.fit(Y)
         assert hasattr(model, "loglik")
 
 
-class TestNloptKargsAutoADAM:
-    """nlopt_kargs forwarded through AutoADAM."""
+class TestNloptKwargsAutoADAM:
+    """nlopt_kwargs forwarded through AutoADAM."""
 
     def test_maxeval_autoadam(self):
         model = AutoADAM(
@@ -112,23 +112,23 @@ class TestNloptKargsAutoADAM:
             lags=[1],
             arima_select=False,
             distribution=["dnorm"],
-            nlopt_kargs={"maxeval": 5},
+            nlopt_kwargs={"maxeval": 5},
         )
         model.fit(Y)
         assert hasattr(model, "loglik")
 
 
-class TestNloptKargsInvalid:
-    """Edge cases for nlopt_kargs values."""
+class TestNloptKwargsInvalid:
+    """Edge cases for nlopt_kwargs values."""
 
     def test_none_is_allowed(self):
-        """nlopt_kargs=None is the default and must work."""
-        model = ADAM(model="ANN", lags=[1], nlopt_kargs=None)
+        """nlopt_kwargs=None is the default and must work."""
+        model = ADAM(model="ANN", lags=[1], nlopt_kwargs=None)
         model.fit(Y)
         assert hasattr(model, "loglik")
 
     def test_unknown_param_raises(self):
         """An unrecognised kwarg should propagate as TypeError from estimator."""
-        model = ADAM(model="ANN", lags=[1], nlopt_kargs={"nonexistent_param": 1})
+        model = ADAM(model="ANN", lags=[1], nlopt_kwargs={"nonexistent_param": 1})
         with pytest.raises(TypeError):
             model.fit(Y)


### PR DESCRIPTION
## What issue does this PR fix?

Renames the misspelled `kargs` identifier to the idiomatic Python `kwargs` throughout the Python package. This covers the public `nlopt_kargs` parameter on `ADAM`, `AutoADAM` (forwarded), `OM`, `OMG`, and `AutoOM`, the internal plumbing that forwards it through the estimator/selector, and the local `kargs` variables inside the OM/OMG optimiser routines. Docs and the test suite are updated to match, and the test module is renamed accordingly

## Language

- [ ] R
- [X] Python
- [ ] Other?

## AI assistance

- [X] AI was used in the creation of this PR

**If yes — how was AI used?**
I asked Copilot to rename all instances of kargs to kwargs
<!-- Describe specifically: e.g. "GitHub Copilot for autocompletion", "ChatGPT to generate unit tests", "Claude to draft the algorithm" -->
