### PR TITLE
Update repo URLs from config-i1/smooth to openforecast-org/smooth

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: 💬 Discussions
-    url: https://github.com/config-i1/smooth/discussions
+    url: https://github.com/openforecast-org/smooth/discussions
     about: Ask questions or discuss forecasting techniques here.

--- a/.github/ISSUE_TEMPLATE/documentation_imp.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_imp.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Where is the improvement needed?
       description: Provide a link to the documentation page or the path to the file in the repo.
-      placeholder: "e.g., https://github.com/config-i1/smooth/wiki/ADAM or /R/adam.R"
+      placeholder: "e.g., https://github.com/openforecast-org/smooth/wiki/ADAM or /R/adam.R"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/build-release-wheels.yml
+++ b/.github/workflows/build-release-wheels.yml
@@ -254,7 +254,7 @@ jobs:
 
             ```bash
             pip install pypi-attestations
-            pypi-attestations verify pypi --repository https://github.com/config-i1/smooth smooth-*.whl
+            pypi-attestations verify pypi --repository https://github.com/openforecast-org/smooth smooth-*.whl
             ```
 
             ## What's Changed

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,8 @@ Version: 4.5.1
 Date: 2026-06-19
 Authors@R: person("Ivan", "Svetunkov", email = "ivan@svetunkov.com", role = c("aut", "cre"),
                   comment="Senior Lecturer at Centre for Marketing Analytics and Forecasting, Lancaster University, UK")
-URL: https://github.com/config-i1/smooth
-BugReports: https://github.com/config-i1/smooth/issues
+URL: https://github.com/openforecast-org/smooth
+BugReports: https://github.com/openforecast-org/smooth/issues
 Language: en-GB
 Description: Functions implementing Single Source of Error state space models for purposes of time series analysis and forecasting.
              The package includes ADAM (Svetunkov, 2023, <https://openforecast.org/adam/>),

--- a/NEWS
+++ b/NEWS
@@ -230,7 +230,7 @@ smooth v4.0.0 (Release data: 2023-09-15)
 =======
 
 Changes:
-* Starting from v4.0.0, the smooth package for R will be released under the LGPLv2.1 license. The source of the older version of the software under the GPL(>=2) is available here: https://github.com/config-i1/smooth/releases/tag/v3.2.2
+* Starting from v4.0.0, the smooth package for R will be released under the LGPLv2.1 license. The source of the older version of the software under the GPL(>=2) is available here: https://github.com/openforecast-org/smooth/releases/tag/v3.2.2
 
 
 smooth v3.2.2 (Release data: 2023-09-15)
@@ -1448,7 +1448,7 @@ Changes:
 * Removed "TFL" as a cost function type and "asymmetric" as intervals type. The functions still accept these parameters, but the parameters are now hidden, because currently they are not ready for wide audience.
 * Changed how number of parameters is calculated when initials are provided. They should be counted in. Only backcasting now excludes initials in calculation of number of parameters.
 * Prepared vignette for es(), ces(), ssarima(), ges(), sma() and sim.es(). This now includes examples with some comments.
-* Uploaded documentation for the package to github (https://github.com/config-i1/smooth/smooth.pdf). This will be published as working paper and will be available via ResearchGate.
+* Uploaded documentation for the package to github (https://github.com/openforecast-org/smooth/smooth.pdf). This will be published as working paper and will be available via ResearchGate.
 
 Bugfixes:
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,7 @@
       }
       else if(randomNumber==4){
         startUpMessage <- paste0(startUpMessage,"\nAny thoughts or suggestions about the package? ",
-                                 "Have you found a bug? File an issue on github: https://github.com/config-i1/smooth/issues");
+                                 "Have you found a bug? File an issue on github: https://github.com/openforecast-org/smooth/issues");
       }
     }
     startUpMessage <- paste0(startUpMessage,"\n");

--- a/README.md
+++ b/README.md
@@ -8,23 +8,23 @@ R:
 [![Downloads](https://cranlogs.r-pkg.org/badges/smooth)](https://cran.r-project.org/package=smooth)
 [![Conda version](https://img.shields.io/conda/v/conda-forge/r-smooth)](https://anaconda.org/conda-forge/r-smooth)
 [![Conda downloads](https://img.shields.io/conda/dn/conda-forge/r-smooth)](https://anaconda.org/conda-forge/r-smooth)
-[![R-CMD-check](https://github.com/config-i1/smooth/actions/workflows/test.yml/badge.svg)](https://github.com/config-i1/smooth/actions/workflows/test.yml)
+[![R-CMD-check](https://github.com/openforecast-org/smooth/actions/workflows/test.yml/badge.svg)](https://github.com/openforecast-org/smooth/actions/workflows/test.yml)
 
 Python:
 
 [![PyPI version](https://img.shields.io/pypi/v/smooth.svg)](https://pypi.org/project/smooth/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/smooth.svg)](https://pypi.org/project/smooth/)
 [![Python versions](https://img.shields.io/pypi/pyversions/smooth.svg)](https://pypi.org/project/smooth/)
-[![Python CI](https://github.com/config-i1/smooth/actions/workflows/python_ci.yml/badge.svg)](https://github.com/config-i1/smooth/actions/workflows/python_ci.yml)
+[![Python CI](https://github.com/openforecast-org/smooth/actions/workflows/python_ci.yml/badge.svg)](https://github.com/openforecast-org/smooth/actions/workflows/python_ci.yml)
 [![SLSA Build Level 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 Python wheels on PyPI ship with [PEP 740 attestations](https://peps.python.org/pep-0740/) — SLSA Build Level 3 provenance, signed via [Sigstore](https://www.sigstore.dev/) on the GitHub Actions runner that built them. Verifiable client-side with [`pypi-attestations`](https://pypi.org/project/pypi-attestations/).
 
 The **smooth** package implements Single Source of Error (SSOE) state-space models for forecasting and time series analysis, available for both R and Python.
 
-![hex-sticker of the smooth package for R](https://github.com/config-i1/smooth/blob/master/man/figures/smooth-web.png?raw=true) ![hex-sticker of the smooth package for Python](https://github.com/config-i1/smooth/blob/master/python/img/smooth-python-web.png?raw=true)
+![hex-sticker of the smooth package for R](https://github.com/openforecast-org/smooth/blob/master/man/figures/smooth-web.png?raw=true) ![hex-sticker of the smooth package for Python](https://github.com/openforecast-org/smooth/blob/master/python/img/smooth-python-web.png?raw=true)
 
-Both the R and Python versions of **smooth** depend on the [**greybox**](https://github.com/config-i1/greybox) package for distributions, information criteria, and supporting utilities (in Python this also provides the LOWESS smoother). It is installed automatically with **smooth**.
+Both the R and Python versions of **smooth** depend on the [**greybox**](https://github.com/openforecast-org/greybox) package for distributions, information criteria, and supporting utilities (in Python this also provides the LOWESS smoother). It is installed automatically with **smooth**.
 
 
 ## Installation
@@ -37,7 +37,7 @@ install.packages("smooth")
 **R (github):**
 ```r
 if (!require("remotes")) install.packages("remotes")
-remotes::install_github("config-i1/smooth")
+remotes::install_github("openforecast-org/smooth")
 ```
 
 
@@ -48,10 +48,10 @@ pip install smooth
 
 **Python (github, dev):**
 ```bash
-pip install "git+https://github.com/config-i1/smooth.git@master#subdirectory=python"
+pip install "git+https://github.com/openforecast-org/smooth.git@master#subdirectory=python"
 ```
 
-For development versions and system requirements, see the [Installation wiki page](https://github.com/config-i1/smooth/wiki/Installation).
+For development versions and system requirements, see the [Installation wiki page](https://github.com/openforecast-org/smooth/wiki/Installation).
 
 ## Quick Examples
 
@@ -89,10 +89,10 @@ model.fit(y)
 
 ## Documentation
 
-Full documentation is available on the **[GitHub Wiki](https://github.com/config-i1/smooth/wiki)**, including:
+Full documentation is available on the **[GitHub Wiki](https://github.com/openforecast-org/smooth/wiki)**, including:
 
-- [ADAM](https://github.com/config-i1/smooth/wiki/ADAM) - Main unified ETS/ARIMA framework
-- [Function reference](https://github.com/config-i1/smooth/wiki) - All functions and methods
-- [Installation guide](https://github.com/config-i1/smooth/wiki/Installation) - Dependencies and troubleshooting
+- [ADAM](https://github.com/openforecast-org/smooth/wiki/ADAM) - Main unified ETS/ARIMA framework
+- [Function reference](https://github.com/openforecast-org/smooth/wiki) - All functions and methods
+- [Installation guide](https://github.com/openforecast-org/smooth/wiki/Installation) - Dependencies and troubleshooting
 
 **Book:** Svetunkov, I. (2023). *Forecasting and Analytics with the Augmented Dynamic Adaptive Model (ADAM)*. Chapman and Hall/CRC. Online: https://openforecast.org/adam/

--- a/conda/r-smooth/meta.yaml
+++ b/conda/r-smooth/meta.yaml
@@ -64,7 +64,7 @@ test:
     - "\"%R%\" -e \"library('smooth')\""   # [win]
 
 about:
-  home: https://github.com/config-i1/smooth
+  home: https://github.com/openforecast-org/smooth
   license: LGPL-2.1-only
   license_family: LGPL
   license_file:
@@ -75,7 +75,7 @@ about:
     purposes of time series analysis and forecasting. The package includes
     ADAM, Exponential Smoothing, SARIMA, Complex Exponential Smoothing,
     Simple Moving Average, and several simulation functions.
-  dev_url: https://github.com/config-i1/smooth
+  dev_url: https://github.com/openforecast-org/smooth
 
 extra:
   recipe-maintainers:

--- a/conda/smooth/meta.yaml
+++ b/conda/smooth/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/config-i1/smooth/archive/refs/tags/v{{ version }}.tar.gz
+  - url: https://github.com/openforecast-org/smooth/archive/refs/tags/v{{ version }}.tar.gz
     sha256: REPLACE_WITH_ACTUAL_HASH
     folder: .
   - url: https://github.com/RUrlus/carma/archive/v{{ carma_version }}.tar.gz
@@ -55,7 +55,7 @@ test:
     - python -c "from smooth.adam_general.core.adam import ADAM; import numpy as np; y = np.array([10,12,15,13,16,18,20,19,22,25,28,30]); m = ADAM(model='ANN', lags=[1]); m.fit(y); fc = m.predict(h=3); assert len(fc.mean) == 3"
 
 about:
-  home: https://github.com/config-i1/smooth
+  home: https://github.com/openforecast-org/smooth
   license: LGPL-2.1-only
   license_family: LGPL
   license_file: LICENSE
@@ -65,7 +65,7 @@ about:
     (Augmented Dynamic Adaptive Model) for time series forecasting using
     state space models, including ETS, ARIMA, and regression in a unified
     Single Source of Error framework.
-  dev_url: https://github.com/config-i1/smooth
+  dev_url: https://github.com/openforecast-org/smooth
 
 extra:
   recipe-maintainers:

--- a/conda/submit.sh
+++ b/conda/submit.sh
@@ -37,7 +37,7 @@ case "$1" in
         sleep 5
 
         echo "=== Computing SHA256 ==="
-        HASH=$(curl -sL "https://github.com/config-i1/smooth/archive/refs/tags/v1.0.0.tar.gz" | sha256sum | awk '{print $1}')
+        HASH=$(curl -sL "https://github.com/openforecast-org/smooth/archive/refs/tags/v1.0.0.tar.gz" | sha256sum | awk '{print $1}')
         echo "SHA256: ${HASH}"
 
         echo "=== Updating meta.yaml ==="

--- a/python/README.md
+++ b/python/README.md
@@ -3,11 +3,11 @@
 [![PyPI version](https://img.shields.io/pypi/v/smooth.svg)](https://pypi.org/project/smooth/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/smooth.svg)](https://pypi.org/project/smooth/)
 [![Python versions](https://img.shields.io/pypi/pyversions/smooth.svg)](https://pypi.org/project/smooth/)
-[![Python CI](https://github.com/config-i1/smooth/actions/workflows/python_ci.yml/badge.svg)](https://github.com/config-i1/smooth/actions/workflows/python_ci.yml)
+[![Python CI](https://github.com/openforecast-org/smooth/actions/workflows/python_ci.yml/badge.svg)](https://github.com/openforecast-org/smooth/actions/workflows/python_ci.yml)
 [![SLSA Build Level 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 [![License: LGPL-2.1](https://img.shields.io/badge/License-LGPL--2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-![hex-sticker of the smooth package for Python](https://github.com/config-i1/smooth/blob/master/python/img/smooth-python-web.png?raw=true)
+![hex-sticker of the smooth package for Python](https://github.com/openforecast-org/smooth/blob/master/python/img/smooth-python-web.png?raw=true)
 
 Python implementation of the **smooth** package for forecasting and time series analysis using Single Source of Error (SSOE) state-space models.
 
@@ -15,19 +15,19 @@ Every wheel published to PyPI is signed via [Sigstore](https://www.sigstore.dev/
 
 ```bash
 pip install pypi-attestations
-pypi-attestations verify pypi --repository https://github.com/config-i1/smooth smooth-*.whl
+pypi-attestations verify pypi --repository https://github.com/openforecast-org/smooth smooth-*.whl
 ```
 
 The package includes the following models:
 
 - [ADAM](https://openforecast.org/adam/) - Augmented Dynamic Adaptive Model, uniting exponential smoothing, ARIMA and regression, implemented in the `ADAM` class.
-- [ETS](https://github.com/config-i1/smooth/wiki/ES) - Exponential Smoothing in the SSOE state space form, implemented in the `ES` class.
-- [CES](https://github.com/config-i1/smooth/wiki/CES) - Complex Exponential Smoothing with complex-valued smoothing parameters, implemented in the `CES` class (fixed seasonality type) and `AutoCES` class (automatic seasonality selection).
-- [MSARIMA](https://github.com/config-i1/smooth/wiki/MSARIMA) - Multiple seasonal ARIMA in state space form, implemented in the `MSARIMA` class (fixed orders) and `AutoMSARIMA` class (automatic order selection).
-- [OM](https://github.com/config-i1/smooth/wiki/OM) - Occurrence Model for intermittent demand, implemented in the `OM` class (plus `OMG` for the general two-component model and `AutoOM` for automatic type selection).
-- [SMA](https://github.com/config-i1/smooth/wiki/SMA) - Simple Moving Average in state-space form (an AR(m) model with fixed coefficients), implemented in the `SMA` class with automatic order selection.
+- [ETS](https://github.com/openforecast-org/smooth/wiki/ES) - Exponential Smoothing in the SSOE state space form, implemented in the `ES` class.
+- [CES](https://github.com/openforecast-org/smooth/wiki/CES) - Complex Exponential Smoothing with complex-valued smoothing parameters, implemented in the `CES` class (fixed seasonality type) and `AutoCES` class (automatic seasonality selection).
+- [MSARIMA](https://github.com/openforecast-org/smooth/wiki/MSARIMA) - Multiple seasonal ARIMA in state space form, implemented in the `MSARIMA` class (fixed orders) and `AutoMSARIMA` class (automatic order selection).
+- [OM](https://github.com/openforecast-org/smooth/wiki/OM) - Occurrence Model for intermittent demand, implemented in the `OM` class (plus `OMG` for the general two-component model and `AutoOM` for automatic type selection).
+- [SMA](https://github.com/openforecast-org/smooth/wiki/SMA) - Simple Moving Average in state-space form (an AR(m) model with fixed coefficients), implemented in the `SMA` class with automatic order selection.
 
-The package also provides standalone data generators that mirror R's `sim.*` family — `sim_es`, `sim_ssarima`, `sim_ces`, `sim_gum`, `sim_sma`, and `sim_oes` — plus a `.simulate()` method on fitted `ADAM`, `OM`, and `OMG` objects. See [Simulation Functions](https://github.com/config-i1/smooth/wiki/Simulation-Functions).
+The package also provides standalone data generators that mirror R's `sim.*` family — `sim_es`, `sim_ssarima`, `sim_ces`, `sim_gum`, `sim_sma`, and `sim_oes` — plus a `.simulate()` method on fitted `ADAM`, `OM`, and `OMG` objects. See [Simulation Functions](https://github.com/openforecast-org/smooth/wiki/Simulation-Functions).
 
 All of these are implemented with the support of the following features:
 
@@ -38,7 +38,7 @@ All of these are implemented with the support of the following features:
 - Fine tuning of any elements of ADAM/ETS/ARIMA/Regression
 - A variety of prediction interval construction methods
 
-Like the R version, the Python **smooth** depends on the [**greybox**](https://github.com/config-i1/greybox) package for distributions, information criteria, regressor selection, and the LOWESS smoother. It is installed automatically as a dependency.
+Like the R version, the Python **smooth** depends on the [**greybox**](https://github.com/openforecast-org/greybox) package for distributions, information criteria, regressor selection, and the LOWESS smoother. It is installed automatically as a dependency.
 
 
 ## Installation
@@ -50,10 +50,10 @@ pip install smooth
 
 **From source (development):**
 ```bash
-pip install "git+https://github.com/config-i1/smooth.git@master#subdirectory=python"
+pip install "git+https://github.com/openforecast-org/smooth.git@master#subdirectory=python"
 ```
 
-See the [Installation Guide](https://github.com/config-i1/smooth/wiki/Installation) for platform-specific instructions.
+See the [Installation Guide](https://github.com/openforecast-org/smooth/wiki/Installation) for platform-specific instructions.
 
 
 ## System Requirements
@@ -189,20 +189,20 @@ print(auto.best_model_.model_name)
 
 ## Documentation
 
-- [GitHub Wiki](https://github.com/config-i1/smooth/wiki) - Full documentation
-- [ADAM](https://github.com/config-i1/smooth/wiki/ADAM) - Main unified ETS/ARIMA framework
-- [Installation Guide](https://github.com/config-i1/smooth/wiki/Installation) - Dependencies and troubleshooting
+- [GitHub Wiki](https://github.com/openforecast-org/smooth/wiki) - Full documentation
+- [ADAM](https://github.com/openforecast-org/smooth/wiki/ADAM) - Main unified ETS/ARIMA framework
+- [Installation Guide](https://github.com/openforecast-org/smooth/wiki/Installation) - Dependencies and troubleshooting
 
 The pages below document the models and their Python classes:
 
-- [ADAM](https://github.com/config-i1/smooth/wiki/ADAM) — Augmented Dynamic Adaptive Model — unified ETS/ARIMA/regression framework
-- [AutoADAM](https://github.com/config-i1/smooth/wiki/AutoADAM) — Automatic ADAM with distribution and ARIMA order selection
-- [ES](https://github.com/config-i1/smooth/wiki/ES) — Exponential Smoothing (ETS) wrapper for ADAM
-- [CES](https://github.com/config-i1/smooth/wiki/CES) — Complex Exponential Smoothing (`CES`, `AutoCES`)
-- [MSARIMA](https://github.com/config-i1/smooth/wiki/MSARIMA) — Multiple Seasonal ARIMA (fixed orders) and automatic selection (`AutoMSARIMA`)
-- [OM](https://github.com/config-i1/smooth/wiki/OM) — Occurrence Model for intermittent demand (`OM`, `OMG`, `AutoOM`)
-- [SMA](https://github.com/config-i1/smooth/wiki/SMA) — Simple Moving Average in state-space form with automatic order selection
-- [Simulation Functions](https://github.com/config-i1/smooth/wiki/Simulation-Functions) — `sim_es`, `sim_ssarima`, `sim_ces`, `sim_gum`, `sim_sma`, `sim_oes`, and the `.simulate()` method on fitted models
+- [ADAM](https://github.com/openforecast-org/smooth/wiki/ADAM) — Augmented Dynamic Adaptive Model — unified ETS/ARIMA/regression framework
+- [AutoADAM](https://github.com/openforecast-org/smooth/wiki/AutoADAM) — Automatic ADAM with distribution and ARIMA order selection
+- [ES](https://github.com/openforecast-org/smooth/wiki/ES) — Exponential Smoothing (ETS) wrapper for ADAM
+- [CES](https://github.com/openforecast-org/smooth/wiki/CES) — Complex Exponential Smoothing (`CES`, `AutoCES`)
+- [MSARIMA](https://github.com/openforecast-org/smooth/wiki/MSARIMA) — Multiple Seasonal ARIMA (fixed orders) and automatic selection (`AutoMSARIMA`)
+- [OM](https://github.com/openforecast-org/smooth/wiki/OM) — Occurrence Model for intermittent demand (`OM`, `OMG`, `AutoOM`)
+- [SMA](https://github.com/openforecast-org/smooth/wiki/SMA) — Simple Moving Average in state-space form with automatic order selection
+- [Simulation Functions](https://github.com/openforecast-org/smooth/wiki/Simulation-Functions) — `sim_es`, `sim_ssarima`, `sim_ces`, `sim_gum`, `sim_sma`, `sim_oes`, and the `.simulate()` method on fitted models
 
 **Book:** Svetunkov, I. (2023). *Forecasting and Analytics with the Augmented Dynamic Adaptive Model (ADAM)*. Chapman and Hall/CRC. Online: https://openforecast.org/adam/
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,11 +51,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage      = "https://github.com/config-i1/smooth"
+Homepage      = "https://github.com/openforecast-org/smooth"
 Documentation = "https://openforecast.org/smooth-py/"
-Repository    = "https://github.com/config-i1/smooth"
-Issues        = "https://github.com/config-i1/smooth/issues"
-Changelog     = "https://github.com/config-i1/smooth/blob/Python/python/NEWS.md"
+Repository    = "https://github.com/openforecast-org/smooth"
+Issues        = "https://github.com/openforecast-org/smooth/issues"
+Changelog     = "https://github.com/openforecast-org/smooth/blob/Python/python/NEWS.md"
 "R package"   = "https://cran.r-project.org/package=smooth"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Point all GitHub URLs (README badges/links, DESCRIPTION URL/BugReports, conda recipes, pyproject, workflows, issue templates, R/zzz.R, NEWS) at the openforecast-org org after the repository move. The conda recipe-maintainers handle (config-i1) is left unchanged; it names a person, not the org.


Claude-Session: https://claude.ai/code/session_014uFNLn5iC7hvWyBG8LtbcF